### PR TITLE
pre-commit yamlfix: exclude folders

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,4 +23,5 @@ repos:
         name: yamlfix
         types: [yaml]
         language: system
-        entry: yamlfix --exclude ".kubernetes/**/*" .
+        entry: yamlfix --exclude ".kubernetes/**/*" --exclude ".venv/**/*" --exclude
+          "dbt_packages/**/*" --exclude "target/**/*" .


### PR DESCRIPTION
Tem três pasta que estão no `.gitignore` e que não foi ignorada na hora que executar `yamlfix`.

O pre-commit demora bastate e no final tem um erro.

Altera um `schema.yml` e faz um commit.

```
git commit -m "message"
check for added large files..............................................Passed
check for merge conflicts................................................Passed
detect private key.......................................................Passed
fix end of files.........................................................Passed
fix utf-8 byte order marker..............................................Passed
don't commit to branch...................................................Passed
trim trailing whitespace.................................................Passed
sqlfmt...............................................(no files to check)Skipped
yamlfix..................................................................Failed
- hook id: yamlfix
- exit code: 1
- files were modified by this hook

[+] YamlFix: Fixing files
[+] Fixed models/br_anatel_banda_larga_fixa/schema.yml
[+] Fixed models/br_tse_eleicoes/schema.yml
Traceback (most recent call last):
  File "/home/pedro/Desktop/bd/queries-basedosdados-dev/.venv/bin/yamlfix", line 8, in <module>
    sys.exit(cli())
  File "/home/pedro/Desktop/bd/queries-basedosdados-dev/.venv/lib/python3.9/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
  File "/home/pedro/Desktop/bd/queries-basedosdados-dev/.venv/lib/python3.9/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
  File "/home/pedro/Desktop/bd/queries-basedosdados-dev/.venv/lib/python3.9/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/pedro/Desktop/bd/queries-basedosdados-dev/.venv/lib/python3.9/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
  File "/home/pedro/Desktop/bd/queries-basedosdados-dev/.venv/lib/python3.9/site-packages/yamlfix/entrypoints/cli.py", line 119, in cli
    fixed_code, changed = services.fix_files(files_to_fix, check, config)
  File "/home/pedro/Desktop/bd/queries-basedosdados-dev/.venv/lib/python3.9/site-packages/yamlfix/services.py", line 83, in fix_files
    fixed_source = fix_code(source, config)
  File "/home/pedro/Desktop/bd/queries-basedosdados-dev/.venv/lib/python3.9/site-packages/yamlfix/services.py", line 162, in fix_code
    source_code = fixer.fix(source_code=source_code)
  File "/home/pedro/Desktop/bd/queries-basedosdados-dev/.venv/lib/python3.9/site-packages/yamlfix/adapters.py", line 363, in fix
    source_code = fixer(source_code)
  File "/home/pedro/Desktop/bd/queries-basedosdados-dev/.venv/lib/python3.9/site-packages/yamlfix/adapters.py", line 381, in _ruamel_yaml_fixer
    for source_dict in source_dicts:
  File "/home/pedro/Desktop/bd/queries-basedosdados-dev/.venv/lib/python3.9/site-packages/ruyaml/main.py", line 477, in load_all
    yield constructor.get_data()
  File "/home/pedro/Desktop/bd/queries-basedosdados-dev/.venv/lib/python3.9/site-packages/ruyaml/constructor.py", line 134, in get_data
    return self.construct_document(self.composer.get_node())
  File "/home/pedro/Desktop/bd/queries-basedosdados-dev/.venv/lib/python3.9/site-packages/ruyaml/composer.py", line 63, in get_node
    return self.compose_document()
  File "/home/pedro/Desktop/bd/queries-basedosdados-dev/.venv/lib/python3.9/site-packages/ruyaml/composer.py", line 96, in compose_document
    node = self.compose_node(None, None)
  File "/home/pedro/Desktop/bd/queries-basedosdados-dev/.venv/lib/python3.9/site-packages/ruyaml/composer.py", line 142, in compose_node
    node = self.compose_mapping_node(anchor)
  File "/home/pedro/Desktop/bd/queries-basedosdados-dev/.venv/lib/python3.9/site-packages/ruyaml/composer.py", line 222, in compose_mapping_node
    item_value = self.compose_node(node, item_key)
  File "/home/pedro/Desktop/bd/queries-basedosdados-dev/.venv/lib/python3.9/site-packages/ruyaml/composer.py", line 110, in compose_node
    if self.parser.check_event(AliasEvent):
  File "/home/pedro/Desktop/bd/queries-basedosdados-dev/.venv/lib/python3.9/site-packages/ruyaml/parser.py", line 150, in check_event
    self.current_event = self.state()
  File "/home/pedro/Desktop/bd/queries-basedosdados-dev/.venv/lib/python3.9/site-packages/ruyaml/parser.py", line 670, in parse_block_mapping_value
    if self.scanner.check_token(ValueToken):
  File "/home/pedro/Desktop/bd/queries-basedosdados-dev/.venv/lib/python3.9/site-packages/ruyaml/scanner.py", line 1827, in check_token
    self._gather_comments()
  File "/home/pedro/Desktop/bd/queries-basedosdados-dev/.venv/lib/python3.9/site-packages/ruyaml/scanner.py", line 1857, in _gather_comments
    self.fetch_more_tokens()
  File "/home/pedro/Desktop/bd/queries-basedosdados-dev/.venv/lib/python3.9/site-packages/ruyaml/scanner.py", line 240, in fetch_more_tokens
    return self.fetch_stream_end()
  File "/home/pedro/Desktop/bd/queries-basedosdados-dev/.venv/lib/python3.9/site-packages/ruyaml/scanner.py", line 462, in fetch_stream_end
    self.remove_possible_simple_key()
  File "/home/pedro/Desktop/bd/queries-basedosdados-dev/.venv/lib/python3.9/site-packages/ruyaml/scanner.py", line 401, in remove_possible_simple_key
    raise ScannerError(
ruyaml.scanner.ScannerError: while scanning a simple key
  in "<unicode string>", line 8, column 1:
    [openssl]
    ^ (line: 8)
could not find expected ':'
  in "<unicode string>", line 8, column 10:
    [openssl]
             ^ (line: 8)


```