### PR TITLE
[Fix] Travar versão do poetry para 1.8.5

### DIFF
--- a/.github/workflows/ci-dbt.yaml
+++ b/.github/workflows/ci-dbt.yaml
@@ -11,7 +11,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Set up poetry
-        run: pipx install poetry
+        run: pipx install poetry==1.8.5
       - name: Set up python
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -19,7 +19,7 @@ jobs:
           secrets: |
             secret/data/queries_credentials/<GCP_PROJECT_NAME>    GCP_SA_KEY | GCP_SA_KEY;
       - name: Set up poetry
-        run: pipx install poetry
+        run: pipx install poetry==1.8.5
       - name: Set up Python
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/metadata_automation.yaml
+++ b/.github/workflows/metadata_automation.yaml
@@ -19,7 +19,7 @@ jobs:
           secrets: |
             secret/data/queries_credentials/basedosdados-dev    GCP_SA_KEY_BASE64 | GCP_SA_KEY_BASE64;
       - name: Set up poetry
-        run: pipx install poetry
+        run: pipx install poetry==1.8.5
       - name: Set up Python
         uses: actions/setup-python@v4
         with:


### PR DESCRIPTION
Travando a versão do poetry para 1.8.5
Versão do poetry 2.0.0 está quebrando um teste.

Solução temporária até melhor avaliação do problema. 