### PR TITLE
[Fix] Atualizar upload-artifact em elementary.yml | Mudar Log not_null_proportion

### DIFF
--- a/.github/workflows/elementary.yml
+++ b/.github/workflows/elementary.yml
@@ -23,13 +23,13 @@ jobs:
           bigquery-keyfile: ${{ secrets.BIGQUERY_KEYFILE }}
           gcs-keyfile: ${{ secrets.GCS_KEYFILE }}
       - name: Upload report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: report.html
           path: report.html
       - name: Upload log
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: edr.log
           path: edr.log

--- a/tests/generic/not_null_proportion_multiple_columns.sql
+++ b/tests/generic/not_null_proportion_multiple_columns.sql
@@ -69,6 +69,7 @@
                             " - "
                             ~ colors.vermelho
                             ~ "Coluna totalmente vazia!"
+                            ~ colors.reset
                         ) %}
                     {% endif %}
 
@@ -76,18 +77,18 @@
                         log(
                             "Coluna: "
                             ~ e
-                            ~ " - Quantidade: "
+                            ~ " - Resultado: "
+                            ~ colors.vermelho
+                            ~ "FAIL"
+                            ~ colors.reset
+                            ~ recommended_message
+                            ~ " - Quantidade Null: "
                             ~ errors["quantity"][loop.index0]
                             ~ " - Total: "
                             ~ errors["total_records"][loop.index0]
                             ~ " - Proporção Null: "
                             ~ "%0.2f"
-                            | format(proc_err | float)
-                            ~ recommended_message
-                            ~ " - Resultado: "
-                            ~ colors.vermelho
-                            ~ "FAIL"
-                            ~ colors.reset,
+                            | format(proc_err | float),
                             info=True,
                         )
                     }}


### PR DESCRIPTION
# [Fix] Atualizar upload-artifact em elementary.yml | Mudar Log not_null_proportion

## Atualizar upload-artifact em elementary.yml
> [!WARNING]
> actions/upload-artifact@v3 is scheduled for deprecation on **November 30, 2024**. [Learn more.](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/)
> Similarly, v1/v2 are scheduled for deprecation on **June 30, 2024**.
> Please update your workflow to use v4 of the artifact actions.
> This deprecation will not impact any existing versions of GitHub Enterprise Server being used by customers.

## Mudar Log not_null_proportion 

### Casos onde o `at_least` está maior do que a coluna consegui preencher
![image](https://github.com/user-attachments/assets/65d0757c-1dd6-477d-a5e0-797b3043b907)
### Casos onde a coluna está totalmente vazia
![image](https://github.com/user-attachments/assets/151ad963-68b1-4752-a5f6-8744643ad4b9)


- ` Proporção Null` indica melhor que a o numero é referente a proporção de linhas vazias na tabela
- `'at_least' Recomendado` agora indica o valor que `at_least` precisa ter para que o test tenha sucesso nessa coluna
- `Qualidade` renomeado para `Qualidade Null`
- Caso a coluna esteja totalmente vazia. Um aviso vai ser destacado,
- Foi colocado cor para realçar a recomendação de `'at_least' Recomendado`
- Cor vermelha no texto `FAIL` para deixa claro que apesar da cor amarela da recomendação, essa coluna falhou no teste